### PR TITLE
Write QGC-compatible param files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ options:
 $ tlog_param.py --help
 usage: tlog_param.py [-h] [-r] paths [paths ...]
 
-Read MAVLink PARAM_VALUE messages from a tlog file (telemetry log) and use these to reconstruct the parameter state of a vehicle.
+Read MAVLink PARAM_VALUE messages from a tlog file (telemetry log), reconstruct the parameter state of a
+vehicle, and write the parameters to a QGC-compatible params file.
 
 positional arguments:
   paths

--- a/tlog_param.py
+++ b/tlog_param.py
@@ -1,39 +1,72 @@
 #!/usr/bin/env python3
 
 """
-Read MAVLink PARAM_VALUE messages from a tlog file (telemetry log) and use these to reconstruct the parameter state of a vehicle.
+Read MAVLink PARAM_VALUE messages from a tlog file (telemetry log), reconstruct the parameter state of a vehicle, and
+write the parameters to a QGC-compatible params file.
 """
 
 from argparse import ArgumentParser
 import os
 from pymavlink import mavutil
+from typing import NamedTuple
 import util
 
 # Use MAVLink2
 os.environ['MAVLINK20'] = '1'
 
 
-class TelemetryLogParam:
-    def __init__(self, tlog_filename: str):
-        self.tlog_filename = tlog_filename
-
-    def read_and_report(self):
-        print(f'Results for {self.tlog_filename}')
-        mlog = mavutil.mavlink_connection(self.tlog_filename, robust_parsing=False, dialect='ardupilotmega')
-
-        params = {}
-        while (msg := mlog.recv_match(blocking=False, type=['PARAM_VALUE'])) is not None:
-            data = msg.to_dict()
-            params[data['param_id']] = data['param_value']
-
-        # Print results
-        for pi in sorted(params.items()):
-            print(f'{pi[0]} = {pi[1]}')
+class Param(NamedTuple):
+    value: str
+    type: str   # Actual values are MAV_PARAM_TYPE_*, but we'll store them as strings
 
 
-# TODO save to a params file that QGC can read & use
-# TODO also save to csv file
-# TODO report interesting info as well, e.g., did params get overridden?
+def read(infile: str) -> dict[str, Param]:
+    mlog = mavutil.mavlink_connection(infile, robust_parsing=False, dialect='ardupilotmega')
+
+    params: dict[str, Param] = {}
+    while (msg := mlog.recv_match(blocking=False, type=['PARAM_VALUE'])) is not None:
+        data = msg.to_dict()
+        param_id = data['param_id']
+        param_value = data['param_value']
+
+        if param_id in params and params[param_id].value != param_value:
+            print(f'{param_id} was {params[param_id].value}, changed to {param_value}')
+
+        params[param_id] = Param(param_value, data['param_type'])
+
+    return params
+
+
+# TODO write ArduSub version #
+# TODO write ArduSub git revision #
+
+def write(params: dict[str, Param], outfile: str):
+    """
+    Write a QGC-compatible params file
+
+    File format: https://dev.qgroundcontrol.com/master/en/file_formats/parameters.html
+    """
+    if len(params) == 0:
+        print('Nothing to write')
+        return
+
+    print(f'Writing {outfile}')
+    f = open(outfile, 'w')
+
+    f.write('# Onboard parameters for Vehicle 1\n')
+    f.write('#\n')
+    f.write('# Stack: ArduPilot\n')
+    f.write('# Vehicle: Sub\n')
+    f.write('# Version: TODO \n')
+    f.write('# Git Revision: TODO\n')
+    f.write('#\n')
+    f.write('# Vehicle-Id\tComponent-Id\tName\tValue\tType\n')
+
+    for pi in sorted(params.items()):
+        f.write(f'1\t1\t{pi[0]}\t{pi[1].value}\t{pi[1].type}\n')
+
+    f.close()
+
 
 def main():
     parser = ArgumentParser(description=__doc__)
@@ -43,10 +76,13 @@ def main():
     files = util.expand_path(args.paths, args.recurse, '.tlog')
     print(f'Processing {len(files)} files')
 
-    for file in files:
+    for infile in files:
         print('-------------------')
-        tlog_param = TelemetryLogParam(file)
-        tlog_param.read_and_report()
+        print(infile)
+        dirname, basename = os.path.split(infile)
+        root, ext = os.path.splitext(basename)
+        outfile = os.path.join(dirname, root + '.params')
+        write(read(infile), outfile)
 
 
 if __name__ == '__main__':

--- a/tlog_param.py
+++ b/tlog_param.py
@@ -36,7 +36,7 @@ class Param(NamedTuple):
     type: str   # Actual values are MAV_PARAM_TYPE_*, but we'll store them as strings
 
 
-class ParamState:
+class TelemetryLogParam:
     def __init__(self):
         self.params: dict[str, Param] = {}
         self.autopilot_version: str = ''
@@ -108,9 +108,9 @@ def main():
         root, ext = os.path.splitext(basename)
         outfile = os.path.join(dirname, root + '.params')
 
-        param_state = ParamState()
-        param_state.read(infile)
-        param_state.write(outfile)
+        tlog_param = TelemetryLogParam()
+        tlog_param.read(infile)
+        tlog_param.write(outfile)
 
 
 if __name__ == '__main__':

--- a/tlog_param.py
+++ b/tlog_param.py
@@ -19,16 +19,13 @@ os.environ['MAVLINK20'] = '1'
 
 
 def firmware_version_type_str(firmware_version_type: int) -> str:
-    if firmware_version_type == mav_common.FIRMWARE_VERSION_TYPE_DEV:
-        return 'dev'
-    elif firmware_version_type == mav_common.FIRMWARE_VERSION_TYPE_ALPHA:
-        return 'alpha'
-    elif firmware_version_type == mav_common.FIRMWARE_VERSION_TYPE_BETA:
-        return 'beta'
-    elif firmware_version_type == mav_common.FIRMWARE_VERSION_TYPE_RC:
-        return 'rc'
-    else:
-        return ''
+    try:
+        return mav_common.enums['FIRMWARE_VERSION_TYPE'][firmware_version_type].description
+
+    except KeyError:
+        pass
+
+    return ''
 
 
 class Param(NamedTuple):
@@ -71,7 +68,7 @@ class TelemetryLogParam:
 
         File format: https://dev.qgroundcontrol.com/master/en/file_formats/parameters.html
         """
-        if len(self.params) == 0:
+        if not len(self.params):
             print('Nothing to write')
             return
 
@@ -87,8 +84,8 @@ class TelemetryLogParam:
         f.write('#\n')
         f.write('# Vehicle-Id\tComponent-Id\tName\tValue\tType\n')
 
-        for pi in sorted(self.params.items()):
-            f.write(f'1\t1\t{pi[0]}\t{pi[1].value}\t{pi[1].type}\n')
+        for param_item in sorted(self.params.items()):
+            f.write(f'1\t1\t{param_item[0]}\t{param_item[1].value}\t{param_item[1].type}\n')
 
         f.close()
 

--- a/util.py
+++ b/util.py
@@ -5,8 +5,10 @@ import os
 def expand_path(paths: list[str], recurse: bool, ext: str | list[str]) -> set[str]:
     files = set()
 
-    if ext is str:
+    if type(ext) is str:
         ext = [ext]
+
+    # TODO bug: this doesn't expand path/to/dir/*.tlog
 
     for path in paths:
         if os.path.isfile(path):


### PR DESCRIPTION
Make it easy to generate QGC-compatible param files from tlog files.

Also fixed a bug in expand_path().

Next PR is to add some tests.