### PR TITLE
Add a tool to report on BAD_DATA messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,23 @@ options:
   -r, --recurse  enter directories looking for tlog and BIN files
 ~~~
 
+### tlog_bad_data.py
+
+~~~
+$ tlog_bad_data.py -h
+usage: tlog_bad_data.py [-h] [-r] [-v] path [path ...]
+
+Read MAVLink messages from a tlog file (telemetry log) and report on BAD_DATA messages.
+
+positional arguments:
+  path
+
+options:
+  -h, --help     show this help message and exit
+  -r, --recurse  enter directories looking for tlog files
+  -v, --verbose  print a lot more information
+~~~
+
 ### wl_ugps_logger.py
 
 ~~~

--- a/testing/test_tools.py
+++ b/testing/test_tools.py
@@ -7,6 +7,7 @@
 import BIN_merge
 import map_maker
 import show_types
+import tlog_bad_data
 import tlog_info
 import tlog_merge
 import tlog_param
@@ -32,6 +33,10 @@ class TestTools:
 
     def test_BIN_types(self):
         tool = show_types.TypeFinder('testing/small.BIN')
+        tool.read()
+
+    def test_bad_data(self):
+        tool = tlog_bad_data.BadDataFinder('testing/small.tlog')
         tool.read()
 
     def test_tlog_info(self):

--- a/testing/test_tools.py
+++ b/testing/test_tools.py
@@ -36,7 +36,7 @@ class TestTools:
         tool.read()
 
     def test_bad_data(self):
-        tool = tlog_bad_data.BadDataFinder('testing/small.tlog')
+        tool = tlog_bad_data.BadDataFinder('testing/small.tlog', True)
         tool.read()
 
     def test_tlog_info(self):

--- a/tlog_bad_data.py
+++ b/tlog_bad_data.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+"""
+Read MAVLink messages from a tlog file (telemetry log) and report on BAD_DATA messages.
+"""
+
+from argparse import ArgumentParser
+
+from pymavlink import mavutil
+
+import util
+
+
+class BadDataInfo:
+    """
+    Gather data about a BAD_DATA message.
+
+    MAVLink 1 header:
+    uint8_t magic;              ///< protocol magic marker == 0xFE
+    uint8_t len;                ///< Length of payload
+    uint8_t seq;                ///< Sequence of packet
+    uint8_t sysid;              ///< ID of message sender system/aircraft
+    uint8_t compid;             ///< ID of the message sender component
+    uint8_t msgid;              ///< ID of the message
+
+    MAVLink 2 header:
+    uint8_t magic;              ///< protocol magic marker == 0xFD
+    uint8_t len;                ///< Length of payload
+    uint8_t incompat_flags;     ///< flags that must be understood
+    uint8_t compat_flags;       ///< flags that can be ignored if not understood
+    uint8_t seq;                ///< Sequence of packet
+    uint8_t sysid;              ///< ID of message sender system/aircraft
+    uint8_t compid;             ///< ID of the message sender component
+    uint8_t msgid 0:7;          ///< first 8 bits of the ID of the message
+    uint8_t msgid 8:15;         ///< middle 8 bits of the ID of the message
+    uint8_t msgid 16:23;        ///< last 8 bits of the ID of the message
+
+    Reference: https://mavlink.io/en/guide/serialization.html#packet_format
+    """
+
+    def __init__(self, msg):
+        # String w/ error message
+        self.reason = msg.reason
+
+        # Is this a CRC error?
+        self.crc_error = True if msg.reason.find('invalid MAVLink CRC') >= 0 else False
+
+        # Parse the MAVLink header
+        b = bytes(msg.data)
+        self.mavlink2 = True if b[0] == 0xFD else False
+
+        if self.mavlink2:
+            self.sysid = int(b[5])
+            self.compid = int(b[6])
+            self.msg_id = (b[9] << 16) + (b[8] << 8) + b[7]
+        else:
+            self.sysid = int(b[3])
+            self.compid = int(b[4])
+            self.msg_id = int(b[5])
+
+    def __str__(self):
+        return f'BadDataMsg mavlink2={self.mavlink2} sysid={self.sysid} compid={self.compid} msg_id={self.msg_id} reason: {self.reason}'
+
+
+class BadDataFinder:
+    def __init__(self, infile: str, verbose: bool):
+        self.infile = infile
+        self.verbose = verbose
+
+    def read(self):
+        print(f'Results for {self.infile}')
+
+        mlog = mavutil.mavlink_connection(self.infile, dialect='ardupilotmega')
+
+        total_count = 0
+        crc_errors = 0
+        counts = {}
+        while True:
+            try:
+                # It appears that I can't filter for BAD_DATA messages, so get them all
+                msg = mlog.recv_match(blocking=False)
+            except Exception as e:
+                print(f'CRASH WITH ERROR "{e}" READING {self.infile}')
+                return
+
+            if msg is None:
+                break
+
+            if msg.get_type() == 'BAD_DATA':
+                msg_info = BadDataInfo(msg)
+                # Count number of bad messages
+                total_count += 1
+
+                # Count number of bad messages due to CRC errors
+                crc_errors = crc_errors + (1 if msg_info.crc_error else 0)
+
+                # Count by underlying message type
+                if msg_info.msg_id not in counts:
+                    counts[msg_info.msg_id] = 0
+
+                counts[msg_info.msg_id] += 1
+
+                # Verbose!
+                if self.verbose:
+                    print(BadDataInfo(msg))
+
+        for msg_id_item in sorted(counts.items()):
+            print(f'msg_id {msg_id_item[0]} count {msg_id_item[1]}')
+
+        print(f'{total_count} BAD_DATA messages, {crc_errors} of them were CRC errors')
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument('-r', '--recurse', action='store_true', help='enter directories looking for tlog files')
+    parser.add_argument('-v', '--verbose', action='store_true', help='print a lot more information')
+    parser.add_argument('path', nargs='+')
+    args = parser.parse_args()
+    files = util.expand_path(args.path, args.recurse, '.tlog')
+    print(f'Processing {len(files)} files')
+
+    for file in files:
+        print('-------------------')
+        scanner = BadDataFinder(file, args.verbose)
+        scanner.read()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Display information about BAD_DATA messages in a tlog file.

This is terse report for file testing/small.tlog:

```
$ tlog_bad_data.py ~/projects/ardusub_log_tools/testing/small.tlog 
Processing 1 files
-------------------
msg_id 259 count 1
msg_id 260 count 1
msg_id 262 count 1
msg_id 269 count 1
4 BAD_DATA messages, 4 of them were CRC errors

```
This is the verbose report for the same file:

```
$ tlog_bad_data.py -v ~/projects/ardusub_log_tools/testing/small.tlog
Processing 1 files
-------------------
Results for /home/clyde/projects/ardusub_log_tools/testing/small.tlog
BadDataMsg mavlink2=True sysid=1 compid=100 msg_id=259 reason: invalid MAVLink CRC in msgID 259 0xe6d3 should be 0xc733
BadDataMsg mavlink2=True sysid=1 compid=100 msg_id=269 reason: invalid MAVLink CRC in msgID 269 0xfaff should be 0x8407
BadDataMsg mavlink2=True sysid=1 compid=100 msg_id=260 reason: invalid MAVLink CRC in msgID 260 0xfaf8 should be 0xd855
BadDataMsg mavlink2=True sysid=1 compid=100 msg_id=262 reason: invalid MAVLink CRC in msgID 262 0xaa69 should be 0x5628
msg_id 259 count 1
msg_id 260 count 1
msg_id 262 count 1
msg_id 269 count 1
4 BAD_DATA messages, 4 of them were CRC errors

```