### PR TITLE
Updates to support surftrak testing

### DIFF
--- a/BIN_info.py
+++ b/BIN_info.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+"""
+Read dataflash messages from a BIN file and report on anything interesting.
+"""
+
+from argparse import ArgumentParser
+
+from pymavlink import mavutil
+
+import util
+
+
+class DataflashLogInfo:
+    def __init__(self, infile: str):
+        self.infile = infile
+
+        # Count # of msg values
+        self.message_counts = {}
+
+    def read_and_report(self):
+        print(f'Results for {self.infile}')
+        mlog = mavutil.mavlink_connection(self.infile, robust_parsing=False, dialect='ardupilotmega')
+
+        while (msg := mlog.recv_match(blocking=False, type=['MSG'])) is not None:
+            raw_data = msg.to_dict()
+
+            message = raw_data['Message']
+            if message not in self.message_counts:
+                self.message_counts[message] = 0
+            self.message_counts[message] += 1
+
+        # Print results
+        for item in sorted(self.message_counts.items()):
+            print(f'{item[1]:8d}  {item[0]}')
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument('-r', '--recurse', help='enter directories looking for BIN files', action='store_true')
+    parser.add_argument('path', nargs='+')
+    args = parser.parse_args()
+    files = util.expand_path(args.path, args.recurse, '.BIN')
+    print(f'Processing {len(files)} files')
+
+    for file in files:
+        print('-------------------')
+        reader = DataflashLogInfo(file)
+        reader.read_and_report()
+
+
+if __name__ == '__main__':
+    main()

--- a/BIN_merge.py
+++ b/BIN_merge.py
@@ -108,7 +108,10 @@ SURFTRAK_MSG_TYPES = [
 class DataflashTable:
     @staticmethod
     def create_table(msg_type: str):
-        return DataflashTable(msg_type)
+        if msg_type == 'RCIN':
+            return RCINTable()
+        else:
+            return DataflashTable(msg_type)
 
     def __init__(self, msg_type: str):
         self._msg_type = msg_type
@@ -130,6 +133,19 @@ class DataflashTable:
                     print(self._df.head())
 
         return self._df
+
+
+class RCINTable(DataflashTable):
+    def __init__(self):
+        super().__init__('RCIN')
+
+    RC_MAP = [(1, 'pitch'), (2, 'roll'), (3, 'throttle'), (4, 'yaw'), (5, 'forward'), (6, 'lateral')]
+
+    def append(self, row: dict):
+        # Rename a few fields for ease-of-use
+        for item in RCINTable.RC_MAP:
+            row[f'RCIN.C{item[0]}_{item[1]}'] = row.pop(f'RCIN.C{item[0]}')
+        super().append(row)
 
 
 class DataflashLogReader(LogMerger):

--- a/show_types.py
+++ b/show_types.py
@@ -11,9 +11,78 @@ from pymavlink import mavutil
 import util
 
 
+# Everything I've ever seen
+# My comments in [], the rest is from https://ardupilot.org/copter/docs/logmessages.html
+DATAFLASH_DESC = {
+    'AHR2': 'Backup AHRS data',
+    'ARM': 'Arming status changes',
+    'ARSP': 'Airspeed sensor data',
+    'ATSC': 'Scale factors for attitude controller',
+    'ATT': 'Canonical vehicle attitude',
+    'BARO': 'Gathered Barometer data',
+    'BAT': 'Gathered battery data',
+    'CTRL': 'Attitude Control oscillation monitor diagnostics',
+    'CTUN': 'Control Tuning information',
+    'DSF': 'Onboard logging statistics',
+    'DU32': 'Generic 32-bit-unsigned-integer storage',
+    'ERR': 'Specifically coded error messages',
+    'EV': 'Specifically coded event messages',
+    'FILE': '[TODO -- what is this?]',
+    'FMT': 'Message defining the format of messages in this file',
+    'FMTU': 'Message defining units and multipliers used for fields of other messages',
+    'FTN': 'Filter Tuning Message - per motor',
+    'GPA': 'GPS accuracy information',
+    'GPS': 'Information received from GNSS systems attached to the autopilot',
+    'IMU': 'Inertial Measurement Unit data',
+    'MAG': 'Information received from compasses',
+    'MAV': 'GCS MAVLink link statistics',
+    'MAVC': 'MAVLink command we have just executed',
+    'MODE': 'vehicle control mode information',
+    'MOTB': 'Motor mixer information',
+    'MSG': 'Textual messages',
+    'MULT': 'Message mapping from single character to numeric multiplier',
+    'ORGN': 'Vehicle navigation origin or other notable position',
+    'PARM': 'parameter value',
+    'PIDA': 'Proportional/Integral/Derivative gain values for Altitude',
+    'PIDP': 'Proportional/Integral/Derivative gain values for Pitch',
+    'PIDR': 'Proportional/Integral/Derivative gain values for Roll',
+    'PIDY': 'Proportional/Integral/Derivative gain values for Yaw',
+    'PM': 'autopilot system performance and general data dumping ground',
+    'POS': 'Canonical vehicle position [lat/lon/alt]',
+    'PSCD': 'Position Control Down',
+    'PSCE': 'Position Control East',
+    'PSCN': 'Position Control North',
+    'RATE': 'Desired and achieved vehicle attitude rates. Not logged in Fixed Wing Plane modes.',
+    'RCI2': '(More) RC input channels to vehicle',
+    'RCIN': 'RC input channels to vehicle',
+    'RCO2': 'Servo channel output values 15 to 18',
+    'RCOU': 'Servo channel output values 1 to 14',
+    'RFND': 'Rangefinder sensor information',
+    'SIM': 'SITL simulator state [rpy, lat/lon/alt, quat]',
+    'SIM2': 'Additional simulator state [pos from home, vel]',
+    'UNIT': 'Message mapping from single character to SI unit',
+    'VER': '[TODO -- what is this?]',
+    'VIBE': 'Processed (acceleration) vibration information',
+    'XKF1': 'EKF3 estimator outputs',
+    'XKF2': 'EKF3 estimator secondary outputs',
+    'XKF3': 'EKF3 innovations',
+    'XKF4': 'EKF3 variances',
+    'XKF5': 'EKF3 Sensor innovations (primary core) and general dumping ground',
+    'XKFS': 'EKF3 sensor selection',
+    'XKQ': 'EKF3 quaternion defining the rotation from NED to XYZ (autopilot) axes',
+    'XKT': 'EKF3 timing information',
+    'XKTV': 'EKF3 Yaw Estimator States',
+    'XKV1': 'EKF3 State variances (primary core)',
+    'XKV2': 'more EKF3 State Variances (primary core)',
+    'XKY0': 'EKF Yaw Estimator States',
+    'XKY1': 'EKF Yaw Estimator Innovations',
+}
+
+
 class TypeFinder:
     def __init__(self, filename: str):
         self.filename = filename
+        self.is_dataflash = filename.endswith('.BIN')
 
     def read(self):
         mlog = mavutil.mavlink_connection(self.filename, dialect='ardupilotmega')
@@ -39,7 +108,11 @@ class TypeFinder:
             print(f'CRASH WITH ERROR "{e}", SHOWING PARTIAL RESULTS')
 
         for msg_type, msg_count in sorted(msg_counts.items()):
-            print(f'{msg_type:25} {msg_count:6d}')
+            if self.is_dataflash:
+                msg_desc = DATAFLASH_DESC[msg_type] if msg_type in DATAFLASH_DESC else 'TODO -- update tool'
+                print(f'{msg_count:6d}  {msg_type:4}  {msg_desc:82}')
+            else:
+                print(f'{msg_type:25} {msg_count:6d}')
 
 
 def main():

--- a/table_types.py
+++ b/table_types.py
@@ -79,13 +79,8 @@ class HeartbeatTable(Table):
     def get_mode(row):
         if not HeartbeatTable.is_armed(row):
             return 0  # Disarmed
-        elif row['HEARTBEAT.custom_mode'] == 19:
-            return 1  # Armed, manual
-        elif row['HEARTBEAT.custom_mode'] == 2:
-            return 2  # Armed, depth hold
         else:
-            # TODO split stabilize and rng_hold
-            return 3  # Armed, something else (RNG_HOLD?)
+            return row['HEARTBEAT.custom_mode']
 
     def __init__(self):
         super().__init__('HEARTBEAT')

--- a/table_types.py
+++ b/table_types.py
@@ -4,6 +4,10 @@ import pandas as pd
 
 import util
 
+# Look at tables with time_boot_ms fields. Findings:
+# DISTANCE_SENSOR from BlueOS is off by ~450s, so it can't be trusted
+# Good readings from messages from ArduSub (RC_CHANNELS, SYSTEM_TIME, possibly others)
+# tables_with_time_boot_ms = []
 
 class Table:
     @staticmethod
@@ -35,6 +39,13 @@ class Table:
         for key in list(row.keys()):
             if isinstance(row[key], list):
                 row.pop(key)
+
+        # global tables_with_time_boot_ms
+        # for key in list(row.keys()):
+        #     key_str = str(key)
+        #     if key_str.endswith('time_boot_ms') and key_str not in tables_with_time_boot_ms:
+        #         print(f'{key_str} in seconds: {row[key_str] / 1000.0}')
+        #         tables_with_time_boot_ms.append(key_str)
 
         self._rows.append(row)
 

--- a/testing/test_tools.py
+++ b/testing/test_tools.py
@@ -50,7 +50,8 @@ class TestTools:
         tool.read_and_report()
 
     def test_tlog_merge(self):
-        tool = tlog_merge.TelemetryLogReader('testing/small.tlog', ['GLOBAL_POSITION_INT'], 10000, 10000, False, 0, 0)
+        tool = tlog_merge.TelemetryLogReader('testing/small.tlog', ['GLOBAL_POSITION_INT'],
+                                             10000, 10000, False, 0, 0, False, False)
         tool.read_tlog()
         tool.add_rate_field()
         tool.write_merged_csv_file()

--- a/testing/test_tools.py
+++ b/testing/test_tools.py
@@ -9,6 +9,7 @@
 
 import pytest
 
+import BIN_info
 import BIN_merge
 import map_maker
 import show_types
@@ -24,7 +25,7 @@ import util
 
 class TestTools:
 
-    def test_BIN_merge(self):
+    def test_dataflash_merge(self):
         tool = BIN_merge.DataflashLogReader('testing/small.BIN', ['VIBE'], 10000, 10000, False)
         tool.read()
         tool.write_merged_csv_file()
@@ -37,7 +38,7 @@ class TestTools:
         tool = show_types.TypeFinder('testing/small.tlog')
         tool.read()
 
-    def test_BIN_types(self):
+    def test_dataflash_types(self):
         tool = show_types.TypeFinder('testing/small.BIN')
         tool.read()
 
@@ -47,6 +48,10 @@ class TestTools:
 
     def test_tlog_info(self):
         tool = tlog_info.TelemetryLogInfo('testing/small.tlog')
+        tool.read_and_report()
+
+    def test_dataflash_info(self):
+        tool = BIN_info.DataflashLogInfo('testing/small.BIN')
         tool.read_and_report()
 
     def test_tlog_merge(self):

--- a/tlog_merge.py
+++ b/tlog_merge.py
@@ -6,6 +6,12 @@ operation does a forward-fill (data is copied from the previous row), so the res
 substantially larger than the sum of the per-type csv files.
 """
 
+import os
+
+# Bug? I'm seeing mavlink.WIRE_PROTOCOL_VERSION == "1.0" for some QGC-generated tlog files
+# Force WIRE_PROTOCOL_VERSION to be 2.0
+os.environ['MAVLINK20'] = '1'
+
 from argparse import ArgumentParser
 
 from pymavlink import mavutil
@@ -96,6 +102,7 @@ class TelemetryLogReader(LogMerger):
 
         print(f'Reading {self.infile}')
         mlog = mavutil.mavlink_connection(self.infile, robust_parsing=True, dialect='ardupilotmega')
+        print(f'WIRE_PROTOCOL_VERSION {mlog.WIRE_PROTOCOL_VERSION}')
 
         print('Parsing messages')
         msg_count = 0
@@ -195,6 +202,7 @@ def main():
                         help='surftrak-specific analysis, see code')
     parser.add_argument('path', nargs='+')
     args = parser.parse_args()
+    print(f'Starting paths: {args.path}')
     files = util.expand_path(args.path, args.recurse, '.tlog')
     print(f'Processing {len(files)} files')
 

--- a/tlog_merge.py
+++ b/tlog_merge.py
@@ -4,6 +4,20 @@
 Read MAVLink messages from a tlog file (telemetry log) and merge the messages into a single, wide csv file. The merge
 operation does a forward-fill (data is copied from the previous row), so the resulting merged csv file may be
 substantially larger than the sum of the per-type csv files.
+
+HEARTBEAT.mode is a combination of HEARTBEAT.base_mode and HEARTBEAT.custom_mode with these values:
+    -10             disarmed
+      0             armed, stabilize
+      1             armed, acro
+      2             armed, alt_hold
+      3             armed, auto
+      4             armed, guided
+      7             armed, circle
+      9             armed, surface
+     16             armed, pos_hold
+     19             armed, manual
+     20             armed, motor detect
+     21             armed, rng_hold
 """
 
 import os
@@ -12,7 +26,7 @@ import os
 # Force WIRE_PROTOCOL_VERSION to be 2.0
 os.environ['MAVLINK20'] = '1'
 
-from argparse import ArgumentParser
+import argparse
 
 from pymavlink import mavutil
 
@@ -73,6 +87,7 @@ SURFTRAK_MSG_TYPES = [
     'AHRS2',
     'DISTANCE_SENSOR',
     'HEARTBEAT',
+    'RANGEFINDER',
     'RC_CHANNELS',
 ]
 
@@ -175,7 +190,7 @@ class TelemetryLogReader(LogMerger):
 
 
 def main():
-    parser = ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__)
     parser.add_argument('-r', '--recurse', action='store_true',
                         help='enter directories looking for tlog files')
     parser.add_argument('-v', '--verbose', action='store_true',


### PR DESCRIPTION
* show all modes in HEARTBEAT.mode
* add experimental "system_time" option that uses firmware time vs. topside time
* add a "surftrak" option with special handling of sysid and compid; this might be useful for other messages?
* show_types.py shows table descriptions for BIN files
* add BIN_info.py
* calculate average rate for --rate
* sort file paths (all tools)
* add AHRS2Table(Table) and RCChannelsTable(Table) for tlog_merge.py
* add RCINTable(DataflashTable) for BIN_merge.py

Also, force MAVLink wire protocol to 2.0 for tlog_merge.py. This solves a problem where I saw pymavlink decide a tlog file was 1.0 (`2023_06_20_beckett/2023-06-20 07-48-02.tlog`), and so 2.0 fields such as DISTANCE_SENSOR.signal_quality were dropped. Is this a pymavlink bug or limitation? More investigation needed.