### PR TITLE
Add support for segments (--keep option) to some tlog tools

### DIFF
--- a/BIN_info.py
+++ b/BIN_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Read dataflash messages from a BIN file and report on anything interesting.
+Read dataflash messages from a BIN file and report on a few interesting things.
 """
 
 from argparse import ArgumentParser

--- a/file_reader.py
+++ b/file_reader.py
@@ -63,5 +63,5 @@ def add_file_args(parser: argparse.ArgumentParser):
     """
     Add args for working with multiple files.
     """
-    parser.add_argument('-r', '--recurse', action='store_true', help='enter directories looking for tlog files')
+    parser.add_argument('-r', '--recurse', action='store_true', help='enter directories looking for files')
     parser.add_argument('path', nargs='+')

--- a/file_reader.py
+++ b/file_reader.py
@@ -16,7 +16,7 @@ class FileReader(NamedReader):
     Iterate over messages in a file.
     """
 
-    def __init__(self, path: str, types: list[str]):
+    def __init__(self, path: str, types: list[str] | None):
         super().__init__(path)
         self._types = types
         self._conn = mavutil.mavlink_connection(path, dialect='ardupilotmega')
@@ -38,7 +38,7 @@ class FileReaderList:
     Iterate over a list of file readers.
     """
 
-    def __init__(self, args, types: list[str]):
+    def __init__(self, args, types: list[str] | None):
         paths = expand_path(args.path, args.recurse, '.tlog')
         print(f'Reading {len(paths)} file(s)')
         self._types = types

--- a/file_reader.py
+++ b/file_reader.py
@@ -1,0 +1,67 @@
+import argparse
+
+import pymavlink.dialects.v20.ardupilotmega as apm
+from pymavlink import mavutil
+
+from util import expand_path
+
+
+class NamedReader:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class FileReader(NamedReader):
+    """
+    Iterate over messages in a file.
+    """
+
+    def __init__(self, path: str, types: list[str]):
+        super().__init__(path)
+        self._types = types
+        self._conn = mavutil.mavlink_connection(path, dialect='ardupilotmega')
+        print(f'Reading {path}, WIRE_PROTOCOL_VERSION {self._conn.WIRE_PROTOCOL_VERSION}')
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> apm.MAVLink_message:
+        msg = self._conn.recv_match(blocking=False, type=self._types)
+        if msg is None:
+            raise StopIteration
+        else:
+            return msg
+
+
+class FileReaderList:
+    """
+    Iterate over a list of file readers.
+    """
+
+    def __init__(self, args, types: list[str]):
+        paths = expand_path(args.path, args.recurse, '.tlog')
+        print(f'Reading {len(paths)} file(s)')
+        self._types = types
+        self._paths_iter = iter(paths)
+        self._current = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> FileReader:
+        self._current = FileReader(next(self._paths_iter), self._types)
+        return self._current
+
+    def current(self) -> FileReader | None:
+        """
+        Return the current reader w/o advancing, used by SegmentReaderList
+        """
+        return self._current
+
+
+def add_file_args(parser: argparse.ArgumentParser):
+    """
+    Add args for working with multiple files.
+    """
+    parser.add_argument('-r', '--recurse', action='store_true', help='enter directories looking for tlog files')
+    parser.add_argument('path', nargs='+')

--- a/map_maker.py
+++ b/map_maker.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python3
 
 """
-Read csv, tlog or txt files and build Leaflet (interactive HTML) maps from GPS coordinates.
+Read csv and txt files and build Leaflet (interactive HTML) maps from GPS coordinates.
 
 For csv files:
     Latitude column header should be 'gps.lat' or 'lat'
     Longitude column header should be 'gps.lon' or 'lon'
 
-For tlog files, these messages are read:
-    GPS_RAW_INT -- sensor data sent from ArduSub to QGC, will appear as a blue line, should be close to the csv file
-    GLOBAL_POSITION_INT -- the filtered position estimate, green line
-    GPS_INPUT -- sensor data sent from ugps-extension to ArduSub, not filtered, red line
-
-For txt files, look for NMEA 0183 GGA messages of the form r'\$[A-Z]+', e.g., $GPGGA.
+For txt files, look for NMEA 0183 GGA messages of the form $[A-Z]+.
 """
 
 import argparse
@@ -24,9 +19,7 @@ from statistics import fmean
 import folium
 import pandas as pd
 import pynmea2
-from pymavlink import mavutil
 
-import table_types
 import util
 
 
@@ -118,48 +111,6 @@ def build_map_from_csv(infile, outfile, verbose, center, zoom):
         print('GPS information not found')
 
 
-def build_map_from_tlog(infile, outfile, verbose, center, zoom, msg_types, hdop_max):
-    # Create tables
-    tables: dict[str, table_types.Table] = {}
-    for msg_type in msg_types:
-        tables[msg_type] = table_types.Table.create_table(msg_type, verbose=verbose, hdop_max=hdop_max)
-
-    # Read tlog file, don't crash
-    mlog = mavutil.mavlink_connection(infile, robust_parsing=False, dialect='ardupilotmega')
-    try:
-        while True:
-            msg = mlog.recv_match(blocking=False, type=msg_types)
-            if msg is None:
-                break
-
-            msg_type = msg.get_type()
-            raw_data = msg.to_dict()
-            timestamp = getattr(msg, '_timestamp', 0.0)
-
-            # Clean up the data: add the timestamp, remove mavpackettype, and rename the keys
-            clean_data = {'timestamp': timestamp}
-            for key in raw_data.keys():
-                if key != 'mavpackettype':
-                    clean_data[f'{msg_type}.{key}'] = raw_data[key]
-
-            tables[msg_type].append(clean_data)
-
-    except Exception as e:
-        print(f'CRASH WITH ERROR "{e}", PARTIAL RESULTS')
-
-    mm = MapMaker(verbose, center, zoom)
-
-    # Build the map in a specific order
-    if 'GPS_RAW_INT' in msg_types and len(tables['GPS_RAW_INT']):
-        mm.add_table(tables['GPS_RAW_INT'], 'GPS_RAW_INT.lat_deg', 'GPS_RAW_INT.lon_deg', 'blue')
-    if 'GLOBAL_POSITION_INT' in msg_types and len(tables['GLOBAL_POSITION_INT']):
-        mm.add_table(tables['GLOBAL_POSITION_INT'], 'GLOBAL_POSITION_INT.lat_deg', 'GLOBAL_POSITION_INT.lon_deg', 'green')
-    if 'GPS_INPUT' in msg_types and len(tables['GPS_INPUT']):
-        mm.add_table(tables['GPS_INPUT'], 'GPS_INPUT.lat_deg', 'GPS_INPUT.lon_deg', 'red')
-
-    mm.write(outfile)
-
-
 def get_timestamp(line: str):
     match = re.search(r'^[^|]+', line)
     return datetime.strptime(match[0], '%Y-%m-%d %H:%M:%S.%f ')
@@ -204,6 +155,19 @@ def build_map_from_txt(infile, outfile, verbose, center, zoom):
         print("No GGA messages found")
 
 
+def add_map_maker_args(parser: argparse.ArgumentParser):
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='print a lot more information')
+    parser.add_argument('--lat', default=None, type=float_or_none,
+                        help='center the map at this latitude, default is mean of all points')
+    parser.add_argument('--lon', default=None, type=float_or_none,
+                        help='center the map at this longitude, default is mean of all points')
+    parser.add_argument('--zoom', default=18, type=int,
+                        help='initial zoom, default is 18')
+    parser.add_argument('--hdop-max', default=100.0, type=float,
+                        help='reject GPS_INPUT messages where hdop exceeds this limit, default 100.0 (no limit)')
+
+
 def float_or_none(x):
     if x is None:
         return None
@@ -218,28 +182,11 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__)
     parser.add_argument('-r', '--recurse', action='store_true',
                         help='enter directories looking for tlog, csv and txt files')
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help='print a lot more information')
-    parser.add_argument('--lat', default=None, type=float_or_none,
-                        help='center the map at this latitude, default is mean of all points')
-    parser.add_argument('--lon', default=None, type=float_or_none,
-                        help='center the map at this longitude, default is mean of all points')
-    parser.add_argument('--zoom', default=18, type=int,
-                        help='initial zoom, default is 18')
-    parser.add_argument('--types', default=None,
-                        help='comma separated list of message types, the default is GPS_RAW_INT and GPS_GLOBAL_INT')
-    parser.add_argument('--hdop-max', default=100.0, type=float,
-                        help='reject GPS_INPUT messages where hdop exceeds this limit, default 100.0 (no limit)')
     parser.add_argument('path', nargs='+')
     args = parser.parse_args()
-    files = util.expand_path(args.path, args.recurse, ['.csv', '.tlog', '.txt'])
-    print(f'Processing {len(files)} files')
 
-    if args.types:
-        msg_types = args.types.split(',')
-    else:
-        # The default doesn't include GPS_INPUT because of this bug: https://github.com/ArduPilot/pymavlink/issues/807
-        msg_types = ['GLOBAL_POSITION_INT', 'GPS_RAW_INT']
+    files = util.expand_path(args.path, args.recurse, ['.csv', '.txt'])
+    print(f'Processing {len(files)} files')
 
     for infile in files:
         print('-------------------')
@@ -250,8 +197,6 @@ def main():
 
         if ext == '.csv':
             build_map_from_csv(infile, outfile, args.verbose, [args.lat, args.lon], args.zoom)
-        elif ext == '.tlog':
-            build_map_from_tlog(infile, outfile, args.verbose, [args.lat, args.lon], args.zoom, msg_types, args.hdop_max)
         else:
             build_map_from_txt(infile, outfile, args.verbose, [args.lat, args.lon], args.zoom)
 

--- a/map_maker.py
+++ b/map_maker.py
@@ -7,7 +7,8 @@ For csv files:
     Latitude column header should be 'gps.lat' or 'lat'
     Longitude column header should be 'gps.lon' or 'lon'
 
-For txt files, look for NMEA 0183 GGA messages of the form $[A-Z]+.
+For txt files:
+    Look for NMEA 0183 GGA messages of the form $[A-Z]+ at the end of a line of text
 """
 
 import argparse
@@ -164,8 +165,6 @@ def add_map_maker_args(parser: argparse.ArgumentParser):
                         help='center the map at this longitude, default is mean of all points')
     parser.add_argument('--zoom', default=18, type=int,
                         help='initial zoom, default is 18')
-    parser.add_argument('--hdop-max', default=100.0, type=float,
-                        help='reject GPS_INPUT messages where hdop exceeds this limit, default 100.0 (no limit)')
 
 
 def float_or_none(x):
@@ -181,8 +180,9 @@ def float_or_none(x):
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__)
     parser.add_argument('-r', '--recurse', action='store_true',
-                        help='enter directories looking for tlog, csv and txt files')
+                        help='enter directories looking for csv and txt files')
     parser.add_argument('path', nargs='+')
+    add_map_maker_args(parser)
     args = parser.parse_args()
 
     files = util.expand_path(args.path, args.recurse, ['.csv', '.txt'])

--- a/plot_local_position.py
+++ b/plot_local_position.py
@@ -2,6 +2,8 @@
 
 """
 Look for LOCATION_POSITION_NED messages in tlog files, plot x and y, and write PDF files.
+
+Supports segments.
 """
 
 import argparse

--- a/plot_local_position.py
+++ b/plot_local_position.py
@@ -26,8 +26,8 @@ def plot_local_position(reader, outfile: str):
     ys = []
     try:
         for msg in reader:
-            xs.append(msg.x)
-            ys.append(msg.y)
+            xs.append(msg.y)
+            ys.append(msg.x)
 
     except Exception as e:
         print(f'CRASH WITH ERROR "{e}", PARTIAL RESULTS')
@@ -37,6 +37,7 @@ def plot_local_position(reader, outfile: str):
         figure, (plot) = plt.subplots(1)
 
         # Plot
+        plot.set_aspect(1)
         plot.plot(xs, ys)
 
         # [Over]write PDF
@@ -56,8 +57,6 @@ def main():
 
     readers = choose_reader_list(args, MSG_TYPES)
     for reader in readers:
-        print('-------------------')
-        print(reader.name)
         plot_local_position(reader, util.get_outfile_name(reader.name, '', '.pdf'))
 
 

--- a/segment_reader.py
+++ b/segment_reader.py
@@ -94,13 +94,11 @@ class SegmentReaderList:
 
 def add_segment_args(parser: argparse.ArgumentParser):
     """
-    Add args for working with multiple segments.
+    Add args for working with multiple files and multiple segments.
     """
-    parser.add_argument('-k', '--keep', default=None, action='append',
-                        help='Keep these segments; a segment is 2 timestamps separated by a comma, e.g., "100,200"')
-
-    # Include args for working with multiple files
     add_file_args(parser)
+    parser.add_argument('-k', '--keep', default=None, action='append',
+                        help='process just these segments; a segment is 2 timestamps and a name, e.g., start,end,s1')
 
 
 def parse_segment(segment_str: str) -> Segment | None:

--- a/segment_reader.py
+++ b/segment_reader.py
@@ -72,7 +72,7 @@ class SegmentReaderList:
     Iterate over a list of segments.
     """
 
-    def __init__(self, args, segments, types):
+    def __init__(self, args, segments, types: list[str] | None):
         print(f'Reading {len(segments)} segment(s)')
         self._segments_iter = iter(segments)
 

--- a/segment_reader.py
+++ b/segment_reader.py
@@ -1,0 +1,194 @@
+import argparse
+import os
+
+import pymavlink.dialects.v20.ardupilotmega as apm
+
+from file_reader import NamedReader, FileReader, FileReaderList, add_file_args
+
+
+class Segment:
+    """
+    A segment is a collection of messages where the start < timestamp < end.
+    """
+
+    def __init__(self, start: float, end: float, name: str | None = None):
+        self.start = start
+        self.end = end
+
+        if name is None:
+            # This will be used in a filename, so avoid adding dots
+            name = f'{start :.0f}_{end :.0f}'
+
+        self.name = name
+
+    def __repr__(self):
+        return '{' + f'start={self.start}, end={self.end}, name={self.name}' + '}'
+
+
+class SegmentReader(NamedReader):
+    """
+    Iterate over messages in a segment. A segment may span several files.
+    """
+
+    def __init__(self, segment: Segment, file_reader: FileReader, file_readers: FileReaderList | None):
+        super().__init__(build_segment_name(file_reader.name, segment.name))
+        self.segment = segment
+        self.file_reader = file_reader
+        self.file_readers = file_readers
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> apm.MAVLink_message:
+        while True:
+            msg = None
+
+            # Get the next message
+            try:
+                msg = next(self.file_reader)
+            except StopIteration:
+                # If we don't have a list of readers, we're done
+                if self.file_readers is None:
+                    raise StopIteration
+
+                # Get the next file reader, this might raise StopIteration, we do not intercept
+                self.file_reader = next(self.file_readers)
+
+            timestamp = getattr(msg, '_timestamp', 0.0)
+
+            # Ignore messages before the segment start
+            if timestamp < self.segment.start:
+                continue
+
+            # Is the segment over?
+            if timestamp > self.segment.end:
+                raise StopIteration
+
+            return msg
+
+
+class SegmentReaderList:
+    """
+    Iterate over a list of segments.
+    """
+
+    def __init__(self, args, segments, types):
+        print(f'Reading {len(segments)} segment(s)')
+        self._segments_iter = iter(segments)
+
+        # Get a list of file readers, and prime the pump by getting the first file reader
+        self._file_readers = FileReaderList(args, types)
+        next(self._file_readers)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> SegmentReader:
+        # Get the current file reader without advancing, and pass it to the next segment reader
+        file_reader = self._file_readers.current()
+        if file_reader is None:
+            raise StopIteration
+
+        return SegmentReader(next(self._segments_iter), file_reader, self._file_readers)
+
+
+def add_segment_args(parser: argparse.ArgumentParser):
+    """
+    Add args for working with multiple segments.
+    """
+    parser.add_argument('-k', '--keep', default=None, action='append',
+                        help='Keep these segments; a segment is 2 timestamps separated by a comma, e.g., "100,200"')
+    parser.add_argument('-d', '--discard', default=None, action='append',
+                        help='Discard these segments, keep everything else')
+
+    # Include args for working with multiple files
+    add_file_args(parser)
+
+
+def parse_segment(segment_str: str) -> Segment | None:
+    """
+    Parse a --keep string and return a segment.
+    """
+    strs = segment_str.split(',')
+    if len(strs) == 3:
+        start_str, end_str, name = strs
+    elif len(strs) == 2:
+        start_str, end_str = strs
+        name = None
+    else:
+        print(f'ERROR {segment_str} must be "start,end" or "start,end,name"')
+        return None
+
+    try:
+        start = float(start_str)
+    except ValueError:
+        print(f'ERROR {start_str} must be a number')
+        return None
+
+    try:
+        end = float(end_str)
+    except ValueError:
+        print(f'ERROR {end_str} must be a number')
+        return None
+
+    if start < 1e7 or end < 1e7:
+        # TODO implement time-since-start
+        print('Time-since-start not implemented yet')
+        return None
+
+    return Segment(start, end, name)
+
+
+def parse_segments(segment_strs: list[str]) -> list[Segment]:
+    """
+    Parse a list of --keep strings to produce a list of segments.
+    """
+    results = []
+
+    for segment_str in segment_strs:
+        segment = parse_segment(segment_str)
+        if segment is not None:
+            results.append(segment)
+
+    return results
+
+
+def parse_segment_args(keep, discard) -> list[Segment]:
+    """
+    Parse keep and discard arguments to produce a list of segments.
+    """
+    if discard is not None:
+        # TODO implement --discard
+        print('--discard not implemented yet')
+        return []
+
+    if keep is None:
+        return []
+
+    return parse_segments(keep)
+
+
+def choose_reader_list(args, types):
+    """
+    If there are segments return a SegmentReaderList, otherwise return a FileReaderList.
+    """
+    if 'keep' in args and 'discard' in args:
+        segments = parse_segment_args(args.keep, args.discard)
+        if len(segments) > 0:
+            return SegmentReaderList(args, segments, types)
+
+    # Default is a FileReaderList
+    return FileReaderList(args, types)
+
+
+def build_segment_name(first_path: str, segment_name: str):
+    """
+    Build a segment name from 2 parts:
+    1. the directory part ('dirname') of the path of the 1st file in the list
+    2. the segment name the user provided
+
+    E.g., if the first file path for this segment is "./2023_09_15/foo.tlog" and the segment name is "transect1",
+    the result is "./2023_09_15/transect1".
+    """
+    dirname, _ = os.path.split(first_path)
+    return os.path.join(dirname, segment_name)

--- a/segment_reader.py
+++ b/segment_reader.py
@@ -98,8 +98,6 @@ def add_segment_args(parser: argparse.ArgumentParser):
     """
     parser.add_argument('-k', '--keep', default=None, action='append',
                         help='Keep these segments; a segment is 2 timestamps separated by a comma, e.g., "100,200"')
-    parser.add_argument('-d', '--discard', default=None, action='append',
-                        help='Discard these segments, keep everything else')
 
     # Include args for working with multiple files
     add_file_args(parser)
@@ -139,40 +137,24 @@ def parse_segment(segment_str: str) -> Segment | None:
     return Segment(start, end, name)
 
 
-def parse_segments(segment_strs: list[str]) -> list[Segment]:
+def parse_segment_args(keep_args) -> list[Segment]:
     """
-    Parse a list of --keep strings to produce a list of segments.
+    Parse a list of --keep arguments to produce a list of segments.
     """
     results = []
-
-    for segment_str in segment_strs:
-        segment = parse_segment(segment_str)
-        if segment is not None:
-            results.append(segment)
-
+    if keep_args is not None:
+        for keep_arg in keep_args:
+            segment = parse_segment(keep_arg)
+            if segment is not None:
+                results.append(segment)
     return results
-
-
-def parse_segment_args(keep, discard) -> list[Segment]:
-    """
-    Parse keep and discard arguments to produce a list of segments.
-    """
-    if discard is not None:
-        # TODO implement --discard
-        print('--discard not implemented yet')
-        return []
-
-    if keep is None:
-        return []
-
-    return parse_segments(keep)
 
 
 def choose_reader_list(args, types):
     """
     If there are segments return a SegmentReaderList, otherwise return a FileReaderList.
     """
-    segments = parse_segment_args(args.keep, args.discard)
+    segments = parse_segment_args(args.keep)
     if len(segments) > 0:
         return SegmentReaderList(args, segments, types)
     else:

--- a/show_types.py
+++ b/show_types.py
@@ -4,6 +4,11 @@
 Read messages from tlog (telemetry) and BIN (dataflash) logs and report on the message types found.
 """
 
+import os
+
+# Force WIRE_PROTOCOL_VERSION to be 2.0 to get the names of the messages with id > 255
+os.environ['MAVLINK20'] = '1'
+
 from argparse import ArgumentParser
 
 from pymavlink import mavutil

--- a/testing/test_tools.py
+++ b/testing/test_tools.py
@@ -16,6 +16,7 @@ import plot_local_position
 import show_types
 import tlog_bad_data
 import tlog_info
+import tlog_map_maker
 import tlog_merge
 import tlog_param
 import tlog_scan
@@ -32,8 +33,13 @@ class TestTools:
         tool.write_merged_csv_file()
 
     def test_tlog_map_maker(self):
-        map_maker.build_map_from_tlog('testing/small.tlog', 'testing/small.html', False, [None, None], 18,
-                                      ['GLOBAL_POSITION_INT'], 10.0)
+        tlog_map_maker.build_map_from_tlog(FileReader('testing/small.tlog', ['GLOBAL_POSITION_INT']),
+                                           'testing/small.html', False, [None, None], 18, 10.0)
+
+    def test_tlog_map_maker_segment(self):
+        segment_reader = SegmentReader(Segment(1683220544, 1683220546, 'segment99'),
+                                       FileReader('testing/small.tlog', ['GLOBAL_POSITION_INT']), None)
+        tlog_map_maker.build_map_from_tlog(segment_reader, 'testing/segment99.html', False, [None, None], 18, 10.0)
 
     def test_nmea_map_maker(self):
         map_maker.build_map_from_txt('testing/nmea_log.txt', 'testing/nmea_log.html', False, [None, None], 18)

--- a/testing/test_tools.py
+++ b/testing/test_tools.py
@@ -28,7 +28,7 @@ from segment_reader import Segment, SegmentReader, parse_segment_args
 class TestTools:
 
     def test_dataflash_merge(self):
-        tool = BIN_merge.DataflashLogReader('testing/small.BIN', ['VIBE'], 10000, 10000, False)
+        tool = BIN_merge.DataflashLogReader('testing/small.BIN', ['VIBE'], 10000, 10000, False, False)
         tool.read()
         tool.write_merged_csv_file()
 
@@ -165,11 +165,8 @@ class TestTools:
             assert pytest.approx(rate) == message['rate']
 
     def test_parse_segment_args(self):
-        segments = parse_segment_args(
-            ['1683220546.0,1683220547.0,foo', '1683220546,1683220547', 'bar', 'fee,fie'], None)
+        segments = parse_segment_args(['1683220546.0,1683220547.0,foo', '1683220546,1683220547', 'bar', 'fee,fie'])
         assert len(segments) == 2
         s1, s2 = segments
         assert s1.start == 1683220546.0 and s1.end == 1683220547.0 and s1.name == 'foo'
         assert s2.start == 1683220546.0 and s2.end == 1683220547.0 and s2.name == '1683220546_1683220547'
-
-        # TODO test other cases

--- a/testing/test_tools.py
+++ b/testing/test_tools.py
@@ -11,8 +11,8 @@ import pytest
 
 import BIN_info
 import BIN_merge
-import plot_local_position
 import map_maker
+import plot_local_position
 import show_types
 import tlog_bad_data
 import tlog_info
@@ -20,6 +20,8 @@ import tlog_merge
 import tlog_param
 import tlog_scan
 import util
+from file_reader import FileReader
+from segment_reader import Segment, SegmentReader, parse_segment_args
 
 
 class TestTools:
@@ -37,7 +39,13 @@ class TestTools:
         map_maker.build_map_from_txt('testing/nmea_log.txt', 'testing/nmea_log.html', False, [None, None], 18)
 
     def test_plot_local_position(self):
-        plot_local_position.plot_local_position('testing/small.tlog', 'testing/small.pdf')
+        plot_local_position.plot_local_position(FileReader('testing/small.tlog', plot_local_position.MSG_TYPES),
+                                                'testing/small.pdf')
+
+    def test_plot_local_position_segment(self):
+        segment_reader = SegmentReader(Segment(1683220544, 1683220546, 'segment1'),
+                                       FileReader('testing/small.tlog', plot_local_position.MSG_TYPES), None)
+        plot_local_position.plot_local_position(segment_reader, 'testing/segment1.pdf')
 
     def test_tlog_types(self):
         tool = show_types.TypeFinder('testing/small.tlog')
@@ -52,7 +60,7 @@ class TestTools:
         tool.read()
 
     def test_tlog_info(self):
-        tool = tlog_info.TelemetryLogInfo('testing/small.tlog')
+        tool = tlog_info.TelemetryLogInfo(FileReader('testing/small.tlog', tlog_info.MSG_TYPES))
         tool.read_and_report()
 
     def test_dataflash_info(self):
@@ -60,11 +68,18 @@ class TestTools:
         tool.read_and_report()
 
     def test_tlog_merge(self):
-        tool = tlog_merge.TelemetryLogReader('testing/small.tlog', ['GLOBAL_POSITION_INT'],
+        tool = tlog_merge.TelemetryLogReader(FileReader('testing/small.tlog', ['GLOBAL_POSITION_INT']),
                                              10000, 10000, False, 0, 0, False, False, True)
         tool.read_tlog()
         tool.add_rate_field()
         tool.write_merged_csv_file()
+
+    def test_tlog_merge_segment(self):
+        segment_reader = SegmentReader(Segment(1683220544, 1683220546, 'segment1'),
+                                       FileReader('testing/small.tlog', ['GLOBAL_POSITION_INT']), None)
+        tool = tlog_merge.TelemetryLogReader(segment_reader, 10000, 10000, False, 0, 0, False, False, True)
+        tool.read_tlog()
+        assert len(tool.tables['GLOBAL_POSITION_INT_1_1']) == 6
 
     def test_tlog_param(self):
         tool = tlog_param.TelemetryLogParam()
@@ -142,3 +157,13 @@ class TestTools:
 
         for rate, message in zip(rates, messages):
             assert pytest.approx(rate) == message['rate']
+
+    def test_parse_segment_args(self):
+        segments = parse_segment_args(
+            ['1683220546.0,1683220547.0,foo', '1683220546,1683220547', 'bar', 'fee,fie'], None)
+        assert len(segments) == 2
+        s1, s2 = segments
+        assert s1.start == 1683220546.0 and s1.end == 1683220547.0 and s1.name == 'foo'
+        assert s2.start == 1683220546.0 and s2.end == 1683220547.0 and s2.name == '1683220546_1683220547'
+
+        # TODO test other cases

--- a/tlog_backwards.py
+++ b/tlog_backwards.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+"""
+Read MAVLink messages from a tlog file (telemetry log) and check to see if time goes backwards.
+"""
+
+from argparse import ArgumentParser
+
+from file_reader import add_file_args, FileReaderList
+
+
+def check_timestamps(reader):
+    count = 0
+    prev_timestamp = None
+
+    for msg in reader:
+        sysid = msg.get_srcSystem()
+        compid = msg.get_srcComponent()
+        timestamp = getattr(msg, '_timestamp', 0.0)
+
+        if prev_timestamp is not None:
+            if timestamp < prev_timestamp:
+                print(f'Time goes backwards: count={count}, sysid={sysid}, compid={compid}, {prev_timestamp} to {timestamp}')
+
+        count += 1
+        prev_timestamp = timestamp
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    add_file_args(parser)
+    parser.add_argument('--types', default=None, help='comma separated list of message types, default is all types')
+    args = parser.parse_args()
+    readers = FileReaderList(args, args.types)
+    for reader in readers:
+        check_timestamps(reader)
+
+
+if __name__ == '__main__':
+    main()

--- a/tlog_info.py
+++ b/tlog_info.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 """
-Read MAVLink messages from a tlog file (telemetry log) and report on anything interesting.
+Read MAVLink messages from a tlog file (telemetry log) and report on a few interesting things.
+
+Supports segments.
 """
 
-from argparse import ArgumentParser
+import argparse
 
 import pymavlink.dialects.v20.ardupilotmega as apm
 
@@ -230,7 +232,7 @@ class TelemetryLogInfo:
 
 
 def main():
-    parser = ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__)
     add_segment_args(parser)
     args = parser.parse_args()
 

--- a/tlog_info.py
+++ b/tlog_info.py
@@ -12,6 +12,35 @@ from pymavlink import mavutil
 import util
 
 
+class SensorInfo:
+    def __init__(self, description: str):
+        if description == '0x100 laser based position':
+            description = '0x100 laser based position (down-facing sonar rangefinder)'
+
+        self.description = description
+        self.present = 0
+        self.enabled = 0
+        self.healthy = 0
+
+    def count(self, enabled, healthy):
+        self.present += 1
+        if enabled:
+            self.enabled += 1
+        if healthy:
+            self.healthy += 1
+
+    def count_str(self, count: int) -> str:
+        if count == 0:
+            return 'NEVER!'
+        elif count == self.present:
+            return 'always'
+        else:
+            return f'{100.0 * count / self.present :.2f}%'
+
+    def report(self) -> str:
+        return f'{self.description}: enabled {self.count_str(self.enabled)}, healthy {self.count_str(self.healthy)}'
+
+
 class CompInfo:
     @staticmethod
     def sys_name(sys_id: int) -> str:
@@ -66,7 +95,10 @@ class CompInfo:
         # Count # of non-zero SYSTEM_TIME.time_unix_usec values
         self._unix_time = 0
 
-    def scan(self, msg):
+        # Keep stats on sensor health
+        self._sensors_present: dict[int, SensorInfo] | None = None
+
+    def process_msg(self, msg):
         msg_type = msg.get_type()
         data = msg.to_dict()
 
@@ -93,6 +125,22 @@ class CompInfo:
 
             if data['time_unix_usec'] != 0:
                 self._unix_time += 1
+
+        elif msg_type == 'SYS_STATUS':
+
+            if self._sensors_present is None:
+                self._sensors_present = {}
+
+            for bit, entry in apm.enums['MAV_SYS_STATUS_SENSOR'].items():
+                if bit == apm.MAV_SYS_STATUS_SENSOR_ENUM_END:
+                    break
+                if msg.onboard_control_sensors_present & bit:
+                    if bit not in self._sensors_present:
+                        self._sensors_present[bit] = SensorInfo(entry.description)
+
+                    enabled = msg.onboard_control_sensors_enabled & bit
+                    healthy = msg.onboard_control_sensors_health & bit
+                    self._sensors_present[bit].count(enabled, healthy)
 
     def report_heartbeat(self):
         print('            HEARTBEAT')
@@ -134,10 +182,18 @@ class CompInfo:
             print('            SYSTEM_TIME')
             print(f'                         valid time was sent {self._unix_time} time(s)')
 
+    def report_sys_status(self):
+        if self._sensors_present is not None:
+            print('            SYS_STATUS')
+            print('                sensors')
+            for _, info in self._sensors_present.items():
+                print('                         ' + info.report())
+
     def report(self):
         self.report_heartbeat()
         self.report_statustext()
         self.report_system_time()
+        self.report_sys_status()
 
 
 class TelemetryLogInfo:
@@ -151,7 +207,8 @@ class TelemetryLogInfo:
         # Build a dictionary sys_id => system
         # Each system is a dictionary of comp_id => instance of CompInfo
         systems = {}
-        while (msg := mlog.recv_match(blocking=False, type=['HEARTBEAT', 'STATUSTEXT', 'SYSTEM_TIME'])) is not None:
+        while (msg := mlog.recv_match(blocking=False,
+                                      type=['HEARTBEAT', 'STATUSTEXT', 'SYSTEM_TIME', 'SYS_STATUS'])) is not None:
             sys_id = msg.get_srcSystem()
 
             if sys_id not in systems:
@@ -163,7 +220,7 @@ class TelemetryLogInfo:
                 systems[sys_id][comp_id] = CompInfo(sys_id, comp_id)
 
             # Scan records for interesting info
-            systems[sys_id][comp_id].scan(msg)
+            systems[sys_id][comp_id].process_msg(msg)
 
         # Print results
         for si in sorted(systems.items()):
@@ -175,7 +232,8 @@ class TelemetryLogInfo:
 
 def main():
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument('-r', '--recurse', help='enter directories looking for tlog files', action='store_true')
+    parser.add_argument('-r', '--recurse',
+                        help='enter directories looking for tlog files', action='store_true')
     parser.add_argument('path', nargs='+')
     args = parser.parse_args()
     files = util.expand_path(args.path, args.recurse, '.tlog')

--- a/tlog_map_maker.py
+++ b/tlog_map_maker.py
@@ -4,7 +4,7 @@
 Read tlog files and build Leaflet (interactive HTML) maps from GPS coordinates.
 
 By default, read these messages:
-    GPS_RAW_INT -- sensor data sent from ArduSub to QGC, will appear as a blue line, should be close to the csv file
+    GPS_RAW_INT -- sensor data sent from ArduSub to QGC, will appear as a blue line
     GLOBAL_POSITION_INT -- the filtered position estimate, green line
     GPS_INPUT -- sensor data sent from ugps-extension to ArduSub, not filtered, red line
 
@@ -55,7 +55,10 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__)
     add_segment_args(parser)
     add_map_maker_args(parser)
-    parser.add_argument('--types', default=None, help='comma separated list of message types')
+    parser.add_argument('--types', default=None,
+                        help='comma separated list of message types')
+    parser.add_argument('--hdop-max', default=100.0, type=float,
+                        help='reject GPS_INPUT messages where hdop exceeds this limit, default 100.0 (no limit)')
     args = parser.parse_args()
 
     if args.types is None:

--- a/tlog_map_maker.py
+++ b/tlog_map_maker.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""
+Read tlog files and build Leaflet (interactive HTML) maps from GPS coordinates.
+
+By default, read these messages:
+    GPS_RAW_INT -- sensor data sent from ArduSub to QGC, will appear as a blue line, should be close to the csv file
+    GLOBAL_POSITION_INT -- the filtered position estimate, green line
+    GPS_INPUT -- sensor data sent from ugps-extension to ArduSub, not filtered, red line
+
+Supports segments.
+"""
+
+import argparse
+
+import table_types
+import util
+from map_maker import MapMaker, add_map_maker_args
+from segment_reader import add_segment_args, choose_reader_list
+
+
+def build_map_from_tlog(reader, outfile, verbose, center, zoom, hdop_max):
+    tables: dict[str, table_types.Table] = {}
+
+    for msg in reader:
+        msg_type = msg.get_type()
+        raw_data = msg.to_dict()
+        timestamp = getattr(msg, '_timestamp', 0.0)
+
+        # Clean up the data: add the timestamp, remove mavpackettype, and rename the keys
+        clean_data = {'timestamp': timestamp}
+        for key in raw_data.keys():
+            if key != 'mavpackettype':
+                clean_data[f'{msg_type}.{key}'] = raw_data[key]
+
+        if msg_type not in tables:
+            tables[msg_type] = table_types.Table.create_table(msg_type, verbose=verbose, hdop_max=hdop_max)
+
+        tables[msg_type].append(clean_data)
+
+    mm = MapMaker(verbose, center, zoom)
+
+    # Build the map in a specific order
+    if 'GPS_RAW_INT' in tables and len(tables['GPS_RAW_INT']):
+        mm.add_table(tables['GPS_RAW_INT'], 'GPS_RAW_INT.lat_deg', 'GPS_RAW_INT.lon_deg', 'blue')
+    if 'GLOBAL_POSITION_INT' in tables and len(tables['GLOBAL_POSITION_INT']):
+        mm.add_table(tables['GLOBAL_POSITION_INT'], 'GLOBAL_POSITION_INT.lat_deg', 'GLOBAL_POSITION_INT.lon_deg', 'green')
+    if 'GPS_INPUT' in tables and len(tables['GPS_INPUT']):
+        mm.add_table(tables['GPS_INPUT'], 'GPS_INPUT.lat_deg', 'GPS_INPUT.lon_deg', 'red')
+
+    mm.write(outfile)
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__)
+    add_segment_args(parser)
+    add_map_maker_args(parser)
+    parser.add_argument('--types', default=None, help='comma separated list of message types')
+    args = parser.parse_args()
+
+    if args.types is None:
+        # GPS_INPUT may result in a pymavlink crash, see https://github.com/ArduPilot/pymavlink/issues/807
+        # Workaround: `export MAV_IGNORE_CRC=1`
+        msg_types = ['GLOBAL_POSITION_INT', 'GPS_RAW_INT', 'GPS_INPUT']
+    else:
+        msg_types = args.types.split(',')
+
+    readers = choose_reader_list(args, msg_types)
+
+    for reader in readers:
+        outfile = util.get_outfile_name(reader.name, '', '.html')
+        build_map_from_tlog(reader, outfile, args.verbose, [args.lat, args.lon], args.zoom, args.hdop_max)
+
+
+if __name__ == '__main__':
+    main()

--- a/tlog_merge.py
+++ b/tlog_merge.py
@@ -18,6 +18,8 @@ HEARTBEAT.mode is a combination of HEARTBEAT.base_mode and HEARTBEAT.custom_mode
      19             armed, manual
      20             armed, motor detect
      21             armed, rng_hold
+
+Supports segments.
 """
 
 import os
@@ -214,12 +216,12 @@ def main():
                         help='select source system id (default is all source systems)')
     parser.add_argument('--compid', type=int, default=0,
                         help='select source component id (default is all source components)')
-    parser.add_argument('--system-time', action='store_true',
-                        help='Experimental: use ArduSub SYSTEM_TIME.time_boot_ms rather than QGC timestamp')
-    parser.add_argument('--surftrak', action='store_true',
-                        help='Experimental: surftrak-specific analysis, see code')
     parser.add_argument('--split-source', action='store_true',
-                        help='Experimental: split messages by source (sysid, compid)')
+                        help='split messages by source (sysid, compid)')
+    parser.add_argument('--system-time', action='store_true',
+                        help='experimental: use ArduSub SYSTEM_TIME.time_boot_ms rather than QGC timestamp')
+    parser.add_argument('--surftrak', action='store_true',
+                        help='experimental: surftrak-specific analysis, see code')
     args = parser.parse_args()
 
     if args.types:

--- a/tlog_segment.py
+++ b/tlog_segment.py
@@ -2,12 +2,8 @@
 
 """
 Read MAVLink messages from one or more tlog files (telemetry logs), stitch them together in time order, then extract
-and write segments as new, smaller tlog files. The segments can be specified in one of 2 ways:
-
-    Use one or more "--keep x,y" options to specify which segments to keep. x and y are timestamps (see below).
-    Use one or more "--discard x,y" options to specify which segments to discard, the rest are kept.
-
-Timestamps can be specified in 2 ways:
+and write segments as new, smaller tlog files. Segments are specified with one or more "--keep x,y,name" options, where
+x and y are timestamps. Timestamps can be specified in 2 ways:
 
     Seconds since the start of the earliest tlog file in the list, e.g., 100.
     Unix time (seconds since January 1st, 1970 UTC), e.g., 1694633807.
@@ -41,7 +37,7 @@ def main():
                         help='source component id to keep, default is all source components')
     args = parser.parse_args()
 
-    segments = parse_segment_args(args.keep, args.discard)
+    segments = parse_segment_args(args.keep)
     print(f'Segments: {segments}')
 
     if args.types:

--- a/tlog_segment.py
+++ b/tlog_segment.py
@@ -15,7 +15,7 @@ Timestamps can be specified in 2 ways:
 Example: stitch together all tlog files in the current directory, then write 2 smaller tlog files, the first with
 messages from t=100s to t=200s, and the second from t=300s to t=400s.
 
-    tlog_segment.py --keep 100,200 300,400 *.tlog
+    tlog_segment.py --keep 100,200 --keep 300,400 *.tlog
 
 Limitations:
 
@@ -23,53 +23,32 @@ Limitations:
     This only works on tlog files, not BIN (Dataflash) files.
 """
 
-import os
-
-# Bug? I'm seeing mavlink.WIRE_PROTOCOL_VERSION == "1.0" for some QGC-generated tlog files
-# Force WIRE_PROTOCOL_VERSION to be 2.0
-os.environ['MAVLINK20'] = '1'
-
 import argparse
 
-from pymavlink import mavutil
-
-import table_types
-import util
+from segment_reader import add_segment_args, parse_segment_args
 
 
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__)
-    parser.add_argument('-r', '--recurse', action='store_true',
-                        help='enter directories looking for tlog files')
+    add_segment_args(parser)
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='print a lot more information')
-    parser.add_argument('-k', '--keep', default=None, nargs='+',
-                        help='keep these segments, a segment is 2 timestamps separated by a comma, e.g., "100,200"')
-    parser.add_argument('-d', '--discard', default=None, nargs='+',
-                        help='discard these segments, and keep all the others')
     parser.add_argument('--types', default=None,
                         help='comma separated list of message types to keep, the default is all types')
-    parser.add_argument('--max-msgs', type=int, default=500000,
-                        help='stop after processing this number of messages, default is 500K')
     parser.add_argument('--sysid', type=int, default=0,
                         help='source system id to keep, default is all source systems')
     parser.add_argument('--compid', type=int, default=0,
                         help='source component id to keep, default is all source components')
-    parser.add_argument('path', nargs='+')
     args = parser.parse_args()
-    files = util.expand_path(args.path, args.recurse, '.tlog')
-    print(f'Processing {len(files)} files')
+
+    segments = parse_segment_args(args.keep, args.discard)
+    print(f'Segments: {segments}')
 
     if args.types:
         msg_types = args.types.split(',')
         print(f'Looking for these types: {msg_types}')
-    else:
-        msg_types = None
 
-    for file in files:
-        print('===================')
-        print(file)
-        # TODO
+    # TODO implement tlog file writing
 
 
 if __name__ == '__main__':

--- a/tlog_segment.py
+++ b/tlog_segment.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""
+Read MAVLink messages from one or more tlog files (telemetry logs), stitch them together in time order, then extract
+and write segments as new, smaller tlog files. The segments can be specified in one of 2 ways:
+
+    Use one or more "--keep x,y" options to specify which segments to keep. x and y are timestamps (see below).
+    Use one or more "--discard x,y" options to specify which segments to discard, the rest are kept.
+
+Timestamps can be specified in 2 ways:
+
+    Seconds since the start of the earliest tlog file in the list, e.g., 100.
+    Unix time (seconds since January 1st, 1970 UTC), e.g., 1694633807.
+
+Example: stitch together all tlog files in the current directory, then write 2 smaller tlog files, the first with
+messages from t=100s to t=200s, and the second from t=300s to t=400s.
+
+    tlog_segment.py --keep 100,200 300,400 *.tlog
+
+Limitations:
+
+    The user must provide the timestamps by examining the files.
+    This only works on tlog files, not BIN (Dataflash) files.
+"""
+
+import os
+
+# Bug? I'm seeing mavlink.WIRE_PROTOCOL_VERSION == "1.0" for some QGC-generated tlog files
+# Force WIRE_PROTOCOL_VERSION to be 2.0
+os.environ['MAVLINK20'] = '1'
+
+import argparse
+
+from pymavlink import mavutil
+
+import table_types
+import util
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__)
+    parser.add_argument('-r', '--recurse', action='store_true',
+                        help='enter directories looking for tlog files')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='print a lot more information')
+    parser.add_argument('-k', '--keep', default=None, nargs='+',
+                        help='keep these segments, a segment is 2 timestamps separated by a comma, e.g., "100,200"')
+    parser.add_argument('-d', '--discard', default=None, nargs='+',
+                        help='discard these segments, and keep all the others')
+    parser.add_argument('--types', default=None,
+                        help='comma separated list of message types to keep, the default is all types')
+    parser.add_argument('--max-msgs', type=int, default=500000,
+                        help='stop after processing this number of messages, default is 500K')
+    parser.add_argument('--sysid', type=int, default=0,
+                        help='source system id to keep, default is all source systems')
+    parser.add_argument('--compid', type=int, default=0,
+                        help='source component id to keep, default is all source components')
+    parser.add_argument('path', nargs='+')
+    args = parser.parse_args()
+    files = util.expand_path(args.path, args.recurse, '.tlog')
+    print(f'Processing {len(files)} files')
+
+    if args.types:
+        msg_types = args.types.split(',')
+        print(f'Looking for these types: {msg_types}')
+    else:
+        msg_types = None
+
+    for file in files:
+        print('===================')
+        print(file)
+        # TODO
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Some tlog tools move to iterators:
* FileReader iterates over MAVLink messages in a tlog file
* FileReaderList iterates over a list of files

Some tlog tools support segments (the --keep option):
* SegmentReader iterates over MAVLink messages between a start time and an end time
* SegmentReaderList iterates over a list of segments

The general tool `tlog_segment.py` is stubbed out, but not complete.

Overhaul the README.

Other small improvements.